### PR TITLE
Version bump 0.5.1 and real time data posting

### DIFF
--- a/edgetagSDK/build.gradle
+++ b/edgetagSDK/build.gradle
@@ -54,7 +54,7 @@ afterEvaluate {
             release(MavenPublication) {
                 from components.release
                 groupId 'com.edgetag'
-                version '0.5.0'
+                version '0.5.1'
                 artifactId 'Edgetag'
             }
         }

--- a/edgetagSDK/src/main/java/com/edgetag/DependencyInjectorImpl.kt
+++ b/edgetagSDK/src/main/java/com/edgetag/DependencyInjectorImpl.kt
@@ -116,7 +116,6 @@ class DependencyInjectorImpl private constructor(
 
     fun initialize(){
         try {
-            eventRepository.publishEvent()
             InstallRefferal().startClient(mApplication)
             DeviceInfo(mApplication).getAdvertisingId()
         }catch (e:Throwable){

--- a/edgetagSDK/src/main/java/com/edgetag/EdgeTagInternal.kt
+++ b/edgetagSDK/src/main/java/com/edgetag/EdgeTagInternal.kt
@@ -100,21 +100,6 @@ open class EdgeTagInternal : EdgeTagInterface {
         }
     }
 
-    /*private fun validateDisableConsentCheck(disableConsentCheck: Boolean) {
-        if (disableConsentCheck) {
-            val consent = hashMapOf<String, Boolean>()
-            consent.put("all", true)
-            consent(consent, object : CompletionHandler {
-                override fun onSuccess() {
-                }
-
-                override fun onError(code: Int, msg: String) {
-                }
-
-            })
-        }
-    }*/
-
     @Synchronized
     override fun consent(
         consentInfo: HashMap<String, Boolean>,

--- a/edgetagSDK/src/main/java/com/edgetag/data/database/EventDatabaseService.kt
+++ b/edgetagSDK/src/main/java/com/edgetag/data/database/EventDatabaseService.kt
@@ -1,19 +1,7 @@
 package com.edgetag.data.database
 
-import android.util.Log
 import com.edgetag.DependencyInjectorImpl
-import com.edgetag.data.database.entity.EventEntity
-import com.edgetag.model.edgetag.EdgetagMetaData
-import com.edgetag.network.ApiDataProvider
 import com.edgetag.repository.EventRepository
-import com.edgetag.util.Constant
-import com.google.gson.Gson
-import com.google.gson.JsonSyntaxException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
-import retrofit2.Call
 
 class EventDatabaseService {
 
@@ -22,66 +10,5 @@ class EventDatabaseService {
 
     companion object {
         private const val TAG = "EventDatabaseService"
-    }
-
-    fun insertEvent(event: EventEntity) {
-
-        CoroutineScope(Dispatchers.Default).launch {
-            try {
-                DependencyInjectorImpl.getInstance().getEventDatabase().eventDao()
-                        .insertEvent(event)
-            } catch (e: Exception) {
-                Log.e(TAG, e.toString())
-            }
-        }
-    }
-
-    fun getEvents() {
-
-        CoroutineScope(Dispatchers.Default).launch {
-
-            val idTable = ArrayList<Int>()
-            evenDao.getEvents().collect { data ->
-                data.forEach {
-                    try {
-                        if (!idTable.contains(it.id)) {
-                            idTable.add(it.id)
-                            val eventData = it.eventData
-                            Log.d("###Pushing id ", "" + it.id)
-                            Log.d("###Pushing events ", "" + eventData)
-
-                            val eventObject: EdgetagMetaData = Gson().fromJson(eventData.trim(), EdgetagMetaData::class.java)
-
-                            DependencyInjectorImpl.getInstance().getConfigurationManager()
-                                    .publishEvents(eventObject, object : ApiDataProvider<Any?>() {
-                                        override fun onFailed(
-                                                errorCode: Int,
-                                                message: String,
-                                                call: Call<Any?>
-                                        ) {
-                                        }
-
-                                        override fun onError(t: Throwable, call: Call<Any?>) {
-                                        }
-
-                                        override fun onSuccess(data: Any?) {
-                                            CoroutineScope(Dispatchers.Default).launch {
-                                                //Log.d("###deleting id ", "" + it.id)
-                                                evenDao.deleteEvent(it)
-                                            }
-                                        }
-                                    })
-                        }
-                    } catch (e: Exception) {
-                        when (e) {
-                            is JsonSyntaxException, is IllegalStateException -> {
-
-                                evenDao.deleteEvent(it)
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }

--- a/edgetagSDK/src/main/java/com/edgetag/data/database/dao/EventDao.kt
+++ b/edgetagSDK/src/main/java/com/edgetag/data/database/dao/EventDao.kt
@@ -1,18 +1,7 @@
 package com.edgetag.data.database.dao
 
-import androidx.room.*
-import com.edgetag.data.database.entity.EventEntity
-import kotlinx.coroutines.flow.Flow
+import androidx.room.Dao
 
 @Dao
 interface EventDao {
-
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertEvent(event: EventEntity) : Long
-
-    @Query("SELECT * from events")
-    fun getEvents(): Flow<List<EventEntity>>
-
-    @Delete
-    fun deleteEvent(event: EventEntity)
 }

--- a/edgetagSDK/src/main/java/com/edgetag/repository/EventRepository.kt
+++ b/edgetagSDK/src/main/java/com/edgetag/repository/EventRepository.kt
@@ -240,7 +240,7 @@ class EventRepository(private var secureStorage: SharedPreferenceSecureVault) {
     }
 
 
-    private fun pushEvents(event: EdgetagMetaData): Result<String> {
+    /*private fun pushEvents(event: EdgetagMetaData): Result<String> {
         return try {
             val eventEntity = EventEntity(Gson().toJson(event))
             EventDatabaseService().insertEvent(eventEntity)
@@ -253,7 +253,7 @@ class EventRepository(private var secureStorage: SharedPreferenceSecureVault) {
                 )
             )
         }
-    }
+    }*/
 
     private fun publishEvents(event: EdgetagMetaData): Result<String> {
         DependencyInjectorImpl.getInstance().getConfigurationManager()
@@ -426,10 +426,6 @@ class EventRepository(private var secureStorage: SharedPreferenceSecureVault) {
         return packageManager.getActivityInfo(
             this.componentName, PackageManager.GET_META_DATA
         ).loadLabel(packageManager).toString()
-    }
-
-    fun publishEvent() {
-        EventDatabaseService().getEvents()
     }
 
     private fun getConsentInfo():HashMap<String, Boolean>{

--- a/edgetagSDK/src/main/java/com/edgetag/util/Constant.kt
+++ b/edgetagSDK/src/main/java/com/edgetag/util/Constant.kt
@@ -22,7 +22,7 @@ object Constant {
 
   const val BOSDK_MAJOR_VERSION = 0
   const val BOSDK_MINOR_VERSION = 5
-  const val BOSDK_PATCH_VERSION = 0
+  const val BOSDK_PATCH_VERSION = 1
 
   val allowedUserKeys = arrayOf("email", "phone", "firstName","lastName","gender","dateOfBirth","country","state","city","zip")
 


### PR DESCRIPTION
**Old implementation** : Data persist in local device if it get failed for following reasons 
1. Device offline 
2. SDK collect the data but app got killed while transferring of data

When APp re-launch and device regain internet connectivity , events start push to remote server. 

**New Implementation** : As SDK receive the data , it will push to remote server. 